### PR TITLE
Correction in indcoins lemma (Independant random variables)

### DIFF
--- a/lec_00_1_mathematical-background.md
+++ b/lec_00_1_mathematical-background.md
@@ -160,13 +160,13 @@ prime factorization, without proving it. Here is what a proof could look like.
 We will prove the following two lemmas:
 
 
-> # {.lemma #primesfirstlem}
+> # {.lemma title="Existence of prime divisor" #primesfirstlem}
 For every integer $n>1$, there exists a prime $p>1$ that divides
 $n$.
 
 
 
-> # {.lemma #primesseclem}
+> # {.lemma title="Existence of co-prime" #primesseclem}
 For every set of integers $p_1,\ldots,p_k>1$, there exists a number
 $n$ such that none of $p_1,\ldots,p_k$ divide $n$.
 
@@ -232,7 +232,7 @@ For example, the probability that $x$ has an even number of ones is $\Pr[A]$ whe
 In the case $n=3$, $A=\{ 000,011,101,110 \}$, and hence $\Pr[A]=\tfrac{4}{8}=\tfrac{1}{2}$.
 It turns out this is true for every $n$:
 
-> # {.lemma #evenprob}
+> # {.lemma title="Even one's" #evenprob}
 $$\Pr_{x\sim \{0,1\}^n}[ \text{$\sum_{i=0}^{n-1} x_i$ is even }] = 1/2$$
 
 > # { .pause }
@@ -420,7 +420,7 @@ We say that two random variables $X:\{0,1\}^n \rightarrow \R$ and $Y:\{0,1\}^n \
 In other words, $X$ and $Y$ are independent if $\Pr[ X=u \wedge Y=v]=\Pr[X=u]\Pr[Y=v]$ for every $u,v \in \R$.
 For example, if two random variables depend on the result of tossing different coins then they are independent:
 
-> # {.lemma  #indcoins}
+> # {.lemma title="Independant random variables" #indcoins}
 Suppose that $S=\{ s_0,\ldots, s_{k-1} \}$ and $T=\{ t_0 ,\ldots, t_{m-1} \}$ are disjoint subsets of $\{0,\ldots,n-1\}$ and let
 $X,Y:\{0,1\}^n \rightarrow \R$ be random variables such that $X=F(x_{s_0},\ldots,x_{s_{k-1}})$ and $Y=G(x_{t_0},\ldots,x_{t_{m-1}})$ for some functions $F: \{0,1\}^k \rightarrow \R$ and $G: \{0,1\}^m \rightarrow \R$.
 Then $X$ and $Y$ are independent.

--- a/lec_00_1_mathematical-background.md
+++ b/lec_00_1_mathematical-background.md
@@ -429,9 +429,9 @@ Then $X$ and $Y$ are independent.
 The notation in the lemma's statement is a bit cumbersome, but at the end of the day, it simply says that if $X$ and $Y$ are random variables that depend on two disjoint sets $S$ and $T$ of coins (for example, $X$ might be the sum of the first $n/2$ coins, and $Y$ might be the largest consecutive stretch of zeroes in the second $n/2$ coins), then they are independent.
 
 > # {.proof data-ref="indcoins"}
-Let $a,b\in \R$, and let $A = \{ x \in \{0,1\}^k : F(x)=a \}$ and $B=\{ x\in \{0,1\}^m : F(x)=b \}$.
+Let $a,b\in \R$, and let $A = \{ x \in \{0,1\}^k : F(x)=a \}$ and $B=\{ x\in \{0,1\}^m : G(x)=b \}$.
 Since $S$ and $T$ are disjoint, we can reorder the indices so that $S = \{0,\ldots,k-1\}$ and $T=\{k,\ldots,k+m-1\}$ without affecting any of the probabilities.
-Hence we can write $\Pr[X=a \wedge X=b] = |C|/2^n$ where $C= \{ x_0,\ldots,x_{n-1} : (x_0,\ldots,x_{k-1}) \in A \wedge (x_k,\ldots,x_{k+m-1}) \in B \}$.
+Hence we can write $\Pr[X=a \wedge Y=b] = |C|/2^n$ where $C= \{ x_0,\ldots,x_{n-1} : (x_0,\ldots,x_{k-1}) \in A \wedge (x_k,\ldots,x_{k+m-1}) \in B \}$.
 Another way to write this using string concatenation is that $C = \{ xyz : x\in A, y\in B, z\in \{0,1\}^{n-k-m} \}$, and hence $|C|=|A||B|2^{n-k-m}$, which means that
 $$
 \tfrac{|C|}{2^n} = \tfrac{|A|}{2^k}\tfrac{|B|}{2^m}\tfrac{2^{n-k-m}}{2^{n-k-m}}=\Pr[X=a]\Pr[Y=b] .


### PR DESCRIPTION
In definition of set B the membership is defined by function G. When considering the probability of the intersection both the random variables are X.