### PR TITLE
Typos in lec_01 and lec_02

### DIFF
--- a/lec_01_introduction.md
+++ b/lec_01_introduction.md
@@ -571,7 +571,7 @@ A similar (though more involved) argument shows that the impossiblity result sho
 
 ::: {.theorem title="Short keys imply high probability attack" #longkeyhighprob}
 Let $(E,D)$ be an encryption scheme with $L(n)=n+t$. Then there is a function $Eve$ and pair of messages $x_0,x_1$ such that 
-$$\Pr_{k \leftarrow_R \{0,1\}^n b \leftarrow_R \{0,1\}}[ Eve(E_k(x_b) = x_b] \geq 1- 2^{-t-1}\;.$$
+$$\Pr_{k \leftarrow_R \{0,1\}^n, b \leftarrow_R \{0,1\}}[ Eve(E_k(x_b) = x_b)] \geq 1- 2^{-t-1}\;.$$
 :::
 
 
@@ -584,7 +584,7 @@ $$\Pr_{k \leftarrow_R \{0,1\}^n , x \in \{0,1\}^\ell}[ E_k(x) \in S_0 ] \leq 2^{
 We show this by arguing that this bound holds for every fixed $k$, when we take the probability over $x$, and so in particular it holds also for random $k$.
 Indeed, for every fixed $k$, the map $x \mapsto E_k(x)$ is a one-to-one map, and so the distribution of $E_k(x)$ for random $x\in \{0,1\}^n$ is uniform over some set $T_k$ of size $2^{n+t}$.
 For every $k$, the probability over $x$ that $E_k(x) \in S_0$  is equal to 
-$$\tfrac{|T_k \cap S_0|}{|T_k|} \leq \tfrac{|S_0|}{|T_k}| \leq \tfrac{2^n}{2^{n+t}}=2^{-t}$$
+$$\tfrac{|T_k \cap S_0|}{|T_k|} \leq \tfrac{|S_0|}{|T_k|} \leq \tfrac{2^n}{2^{n+t}}=2^{-t}$$
 thus proving [eqlongkeyprobproof](){.eqref}.
 
 Now, for every $x$, define $p_x$ to be $\Pr_{k \leftarrow_R \{0,1\}^n}[ E_k(x) \in S_0]$. By [eqlongkeyprobproof](){.eqref}, the expectation of $p_x$ over random $x \leftarrow_R \{0,1\}^n$ is at most $2^{-t}$ and so in particular by the averaging argument _there exists_ some $x_1$ such that $p_{x_1} \leq 2^{-t}$.

--- a/lec_01_introduction.md
+++ b/lec_01_introduction.md
@@ -571,7 +571,7 @@ A similar (though more involved) argument shows that the impossiblity result sho
 
 ::: {.theorem title="Short keys imply high probability attack" #longkeyhighprob}
 Let $(E,D)$ be an encryption scheme with $L(n)=n+t$. Then there is a function $Eve$ and pair of messages $x_0,x_1$ such that 
-$$\Pr_{k \leftarrow_R \{0,1\}^n, b \leftarrow_R \{0,1\}}[ Eve(E_k(x_b) = x_b)] \geq 1- 2^{-t-1}\;.$$
+$$\Pr_{k \leftarrow_R \{0,1\}^n, b \leftarrow_R \{0,1\}}[ Eve(E_k(x_b)) = x_b] \geq 1- 2^{-t-1}\;.$$
 :::
 
 

--- a/lec_02_computational-security.md
+++ b/lec_02_computational-security.md
@@ -215,7 +215,7 @@ In practice we would usually like to ensure that when we use a smallish security
 
 - The *honest parties* (the parties running the encryption and decryption algorithms) are extremely efficient, something like 100-1000 cycles per byte of data processed. In theory terms we would want them be using an $O(n)$ or at worst $O(n^2)$ time algorithms with not-too-big hidden constants.
 
-- We want to protect against *adversaries* (the parties trying to break the encryption) that  have much vaster computational capabilities. A typical modern encryption is built so that using standard key sizes it can  withstand the combined computational powers of all computers on earth for several decades. In theory terms we would want the time to break the scheme be at least $2^{\Omega(n)}$ or $2^(\Omega(\sqrt{n})$ / $2^{\Omega(n^{1/3})}$ with not too small hidden constants. 
+- We want to protect against *adversaries* (the parties trying to break the encryption) that  have much vaster computational capabilities. A typical modern encryption is built so that using standard key sizes it can  withstand the combined computational powers of all computers on earth for several decades. In theory terms we would want the time to break the scheme be at least $2^{\Omega(n)}$ or $2^{\Omega(\sqrt{n})}$ / $2^{\Omega(n^{1/3})}$ with not too small hidden constants. 
 
 
 
@@ -249,7 +249,7 @@ A function $\mu:\mathbb{N} \rightarrow [0,\infty)$ is _negligible_ if for every 
 The following exercises are good ways to get some comfort with this definition
 
 ::: {.exercise title="Negligible functions properties" #negligible}
-1. Let $\mu:\N \rightarrow [0,\infty)$ be a negligible function. Prove that for every polynomials $p,q:\R \rightarrow \R$ with non-negative coefficients, the function $\mu':\N \rightarrow [0,\infty)$ defined as $\mu'(n) = p(\mu(q(n)))$ is negligible. 
+1. Let $\mu:\N \rightarrow [0,\infty)$ be a negligible function. Prove that for every polynomials $p,q:\R \rightarrow \R$ with non-negative coefficients such that $p(0) = 0$, the function $\mu':\N \rightarrow [0,\infty)$ defined as $\mu'(n) = p(\mu(q(n)))$ is negligible. 
 
 2. Let $\mu:\N \rightarrow \R$. Prove that $\mu$ is negligible if and only if for every constant $c$, $\lim_{n \rightarrow \infty} n^c \mu(n) = 0$.
 :::
@@ -628,7 +628,7 @@ need to show that $E_{U_n}(m) \approx E_{U_n}(m')$. The heart of the proof will
 be the following claim:
 >
 **Claim:** Let $\hat{E}$ be the algorithm that on input a message $m$ and key
-$k_0$ works like $E$ except that its the $i^{th}$ block contains
+$k_0$ works like $E$ except that its $i^{th}$ block contains
 $E'_{k_{i-1}}(k'_i,m_i)$ where $k'_i$ is a *random* string in ${\{0,1\}}^n$,
 that is chosen *independently* of everything else including the key $k_i$. Then,
 for every message $m\in{\{0,1\}}^t$


### PR DESCRIPTION
I think the condition p(0) = 0 is missing in the exercise.